### PR TITLE
Improve custom node library loading

### DIFF
--- a/custom_nodes/types/src/api.d.ts
+++ b/custom_nodes/types/src/api.d.ts
@@ -6,7 +6,53 @@ declare global {
 
 /** Visual Blocks API exposed to "visualblocks" global namespace. */
 export interface VisualBlocksApi {
-  registerCustomNode(info: CustomNodeInfo): void;
+  /**
+   * Register a custom node.
+   *
+   * If you are registering multiple nodes, set 'isLastNode' to false for all
+   * but the last one. This will tell VisualBlocks when you are done registering
+   * nodes. Alternatively, register them all at once with `registerCustomNodes`
+   */
+  registerCustomNode(info: CustomNodeInfo, isLastNode?: boolean): void;
+  /**
+   * Register a list of custom nodes.
+   *
+   * This is preferred over callling `registerCustomNode` individually for each
+   * node since it's easier to control when VisualBlocks is notified that all
+   * the nodes have been registered.
+   */
+  registerCustomNodes(info: CustomNodeInfo[]): void;
+}
+
+/**
+ * ESModules API for implementing custom node libraries
+ *
+ * As an alternative to calling VisualBlocks's `registerCustomNode` function,
+ * you can declare your custom node library as an ESModule. You will need to
+ * ensure that when it is bundled (if you choose to bundle it), it bundles
+ * with the ESModule format. Your final output should have an `export` statement
+ * at the top level.
+ *
+ * Your module should implement the CustomNodeLibrary interface as its default
+ * export. A conventient pattern to do this is using TypeScript's `satisfies`
+ * operator:
+ *
+ * ```
+ * export default {
+ *   registerCustomNodes: (...) => {...},
+ *   ...
+ * } satisfies CustomNodeLibrary;
+ *
+ * Alternatively, Visual Blocks also supports a format where you export each of
+ * the properties of the `CustomNodeLibrary` interface:
+ *
+ * ```
+ * export const registerCustomNodes: CustomNodeLibrary['registerCustomNodes'] = (...) => {...};
+ * ...
+ * ```
+ */
+export interface CustomNodeLibrary {
+  registerCustomNodes(register: VisualBlocksApi['registerCustomNodes']): void | Promise<void>
 }
 
 /** Info for a custom node. */


### PR DESCRIPTION
Custom node libraries can now be written as ESModules by providing your nodes in a module that exports a `registerCustomNodes(register: (nodes: CustomNodeInfo[]) => void): Promise<void> | void;` function. This allows VisualBlocks to know when all the nodes are done being registered.

For commonjs node libraries, there is a
new function `visualblocks.registerCustomNodes` that registers multiple nodes at a time. Calling this function will notify VisualBlocks that all your nodes are loaded.

The original custom node API that uses `visualblocks.registerCustomNode` to register nodes one at a time remains as it was, but there is now a second argument that can be passed to it. This argument is called `isLastNode` and it is `true` by default. Passing `false` will prevent VisualBlocks from assuming that all the nodes are registered. You must pass `true` on your last call to it.

cl/641320539