### PR TITLE
Implement a simple prompt template node in gemini

### DIFF
--- a/custom_nodes/packages/custom-node-types/src/node_spec.d.ts
+++ b/custom_nodes/packages/custom-node-types/src/node_spec.d.ts
@@ -76,7 +76,7 @@ export declare interface NodeSpec {
    */
   dynamicIoGeneratorFn?: (
     inputValues: Record<string, JsonValue>
-  ) => DynamicIoSpecs;
+  ) => DynamicIoSpecs | Promise<DynamicIoSpecs>;
 }
 
 /** NodeSpec with typed custom data. */
@@ -116,7 +116,7 @@ export declare interface OutputSpec {
    * Json object has, and they will be displayed in the node UI as separated
    * output rows so users can easily connect edges to individual fields.
    */
-  fieldSpecs?: OutputSpec[];
+  fieldSpecs?: readonly OutputSpec[];
 
   /**
    * A list of nodes that are recommended to be connected to this output.
@@ -125,7 +125,7 @@ export declare interface OutputSpec {
    * show the list of candidates when hovered over. Clicking a candidate will
    * automatically add the node to the graph and connect it to the output.
    */
-  recommendedNodes?: RecommendedNode[];
+  recommendedNodes?: readonly RecommendedNode[];
 }
 
 /**
@@ -208,7 +208,7 @@ export declare interface InputSpec {
   hideCondition?: HideCondition;
 
   /** See comments in `OutputSpec` above for more details. */
-  fieldSpecs?: InputSpec[];
+  fieldSpecs?: readonly InputSpec[];
 }
 
 /**
@@ -286,8 +286,8 @@ export declare interface RecommendedNode {
 
 /** The object returned by the `dynamicIoGeneratorFn`. */
 export declare interface DynamicIoSpecs {
-  inputSpecs?: InputSpec[];
-  outputSpecs?: OutputSpec[];
+  inputSpecs?: readonly InputSpec[];
+  outputSpecs?: readonly OutputSpec[];
 }
 
 /**

--- a/custom_nodes/packages/gemini/src/index.ts
+++ b/custom_nodes/packages/gemini/src/index.ts
@@ -17,9 +17,10 @@
 
 import {CustomNodeLibrary} from '@visualblocks/custom-node-types';
 import {GeminiModelInfo} from './gemini_model';
+import {PromptTemplateNodeInfo} from './prompt_template';
 
 export default {
   registerCustomNodes: register => {
-    register([GeminiModelInfo]);
+    register([GeminiModelInfo, PromptTemplateNodeInfo]);
   },
 } satisfies CustomNodeLibrary;

--- a/custom_nodes/packages/gemini/src/prompt_template.ts
+++ b/custom_nodes/packages/gemini/src/prompt_template.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2024 Google LLC.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * =============================================================================
+ */
+
+import {
+  CustomNodeInfo,
+  Category,
+  DataType,
+  DynamicIoSpecs,
+  EditorType,
+  InputSpec,
+  InputType,
+  JsonValue,
+  NodeSpec,
+  OutputType,
+} from '@visualblocks/custom-node-types';
+import {PureFunctionNode} from '@visualblocks/node-utils';
+import {GeminiModelInfo} from './gemini_model';
+
+export const NODE_SPEC = {
+  id: 'prompt-template',
+  name: 'Prompt Template',
+  description:
+    'Fill out a prompt template with a given set of inputs. Use {{ variableName }} to define variables to replace in the prompt.',
+  category: Category.PROCESSOR,
+  inputSpecs: [
+    {
+      name: 'template',
+      displayLabel: 'Template',
+      type: DataType.STRING,
+      defaultValue:
+        'Use {{ variableName }} to define variables to replace in the prompt.',
+      editorSpec: {
+        type: EditorType.TEXT_AREA,
+        autoResize: true,
+      },
+    },
+    {
+      name: 'values',
+      type: DataType.UNKNOWN,
+      fieldSpecs: [],
+    },
+  ] as const,
+  outputSpecs: [
+    {
+      name: 'prompt',
+      type: DataType.STRING,
+      recommendedNodes: [
+        {
+          nodeSpecId: GeminiModelInfo.nodeSpec.id,
+          inputId: GeminiModelInfo.nodeSpec.inputSpecs[0].name,
+        },
+      ],
+    },
+  ] as const,
+  dynamicIoGeneratorFn: (
+    inputValues: Record<string, JsonValue>
+  ): DynamicIoSpecs => {
+    const template = inputValues['template'];
+    if (!template || typeof template !== 'string') {
+      return NODE_SPEC;
+    }
+
+    const variableNames = new Set<string>();
+    const variables = getTemplateParts(template)
+      .filter((p: TemplatePart): p is VariablePart => p.type === 'variable')
+      .filter(({name}) => {
+        if (variableNames.has(name)) {
+          return false;
+        }
+        variableNames.add(name);
+        return true;
+      })
+      .map(({name}) => name);
+
+    const fieldSpecs: InputSpec[] = variables.map(name => ({
+      name,
+      type: DataType.STRING,
+      editorSpec: {
+        type: EditorType.TEXT_INPUT,
+      },
+    }));
+
+    return {
+      inputSpecs: [
+        NODE_SPEC.inputSpecs[0],
+        {
+          ...NODE_SPEC.inputSpecs[1],
+          fieldSpecs,
+        },
+      ],
+      outputSpecs: NODE_SPEC.outputSpecs,
+    };
+  },
+} satisfies NodeSpec;
+
+type Inputs = InputType<typeof NODE_SPEC>;
+type Outputs = OutputType<typeof NODE_SPEC>;
+
+interface StringPart {
+  type: 'string';
+  value: string;
+}
+
+interface VariablePart {
+  type: 'variable';
+  name: string;
+}
+
+type TemplatePart = StringPart | VariablePart;
+
+function getTemplateParts(prompt: string): TemplatePart[] {
+  if (prompt.length === 0) {
+    return [
+      {
+        type: 'string',
+        value: '',
+      },
+    ];
+  }
+
+  const parts: TemplatePart[] = [];
+  let inVariableUse = false;
+  let pos = 0;
+
+  while (true) {
+    if (inVariableUse) {
+      const variableEnd = prompt.match(' *}}');
+      if (!variableEnd) {
+        throw new Error(`Variable at ${pos} has no matching '}}'`);
+      }
+      const variableName = prompt.slice(0, variableEnd.index!);
+
+      parts.push({
+        type: 'variable',
+        name: variableName,
+      });
+
+      const advance = variableEnd.index! + variableEnd[0].length;
+      prompt = prompt.slice(advance);
+      pos += advance;
+      inVariableUse = false;
+    } else {
+      const nextVariableStart = prompt.match('{{ *');
+      if (nextVariableStart) {
+        inVariableUse = true;
+        const textBeforeVariable = prompt.slice(0, nextVariableStart.index);
+        parts.push({
+          type: 'string',
+          value: textBeforeVariable,
+        });
+
+        // Cut the variable start token out.
+        const advance = nextVariableStart.index! + nextVariableStart[0].length;
+        prompt = prompt.slice(advance);
+        pos += advance;
+      } else {
+        // No more variable declarations
+        parts.push({
+          type: 'string',
+          value: prompt,
+        });
+        return parts;
+      }
+    }
+  }
+}
+
+export class PromptTemplate extends PureFunctionNode<Inputs, Outputs> {
+  async run({template, values}: Inputs): Promise<Outputs> {
+    if (template == null) {
+      throw new Error('Template input is null or undefined');
+    }
+    if (typeof values !== 'object') {
+      throw new Error(
+        `Expected 'values' to be an object but got '${typeof values}'`
+      );
+    }
+    if (values === null) {
+      throw new Error('Values input is null');
+    }
+
+    const parts = getTemplateParts(template);
+
+    const prompt = parts
+      .map(part => {
+        if (part.type === 'string') {
+          return part.value;
+        }
+
+        const valuesRecord = values as Record<string, string>;
+        if (!(part.name in valuesRecord)) {
+          throw new Error(`Missing value for variable '${part.name}'`);
+        }
+
+        return String(valuesRecord[part.name]);
+      })
+      .join('');
+
+    return {prompt};
+  }
+}
+
+export const PromptTemplateNodeInfo = {
+  nodeSpec: NODE_SPEC,
+  nodeImpl: PromptTemplate,
+} satisfies CustomNodeInfo;

--- a/custom_nodes/packages/node-utils/src/pure_function_node.ts
+++ b/custom_nodes/packages/node-utils/src/pure_function_node.ts
@@ -63,10 +63,6 @@ export abstract class PureFunctionNode<
       return this.forcedRun(inputs, services);
     }
 
-    if (inputs === this.lastInputs) {
-      return this.cachedOutputs;
-    }
-
     for (const key of Object.keys(this.lastInputs)) {
       if (!(key in inputs)) {
         return this.forcedRun(inputs, services);
@@ -87,7 +83,7 @@ export abstract class PureFunctionNode<
   }
 
   async forcedRun(inputs: Inputs, services: Services): Promise<Outputs> {
-    this.lastInputs = inputs;
+    this.lastInputs = structuredClone(inputs);
     this.cachedOutputs = await this.run(inputs, services);
     return this.cachedOutputs;
   }


### PR DESCRIPTION
The prompt template node automatically adds fields to a `values` input that match the `{{ variables }}` used in the template. Alternatively, an object with all the values for the variables can be provided in the `values` input.

![image](https://github.com/user-attachments/assets/0a50014e-6f1d-4089-ba6e-88dc36c77084)

Screenshot from a local devserver. We'll need to publish VisualBlocks again before this will work in OSS, since there are still some unpublished fixes for dynamic IO and fieldspecs.
