### PR TITLE
Standardize some values across package.json files

### DIFF
--- a/custom_nodes/packages/gemini/package.json
+++ b/custom_nodes/packages/gemini/package.json
@@ -2,7 +2,7 @@
   "name": "@visualblocks/gemini",
   "version": "0.1.0",
   "description": "Gemini nodes for Visual Blocks",
-  "module": "index.js",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
   "files": [

--- a/custom_nodes/packages/node-utils/package.json
+++ b/custom_nodes/packages/node-utils/package.json
@@ -1,9 +1,11 @@
 {
   "name": "@visualblocks/node-utils",
   "version": "0.0.0",
-  "module": "./dist/index.js",
+  "description": "Utilities for writing custom Visual Blocks nodes",
+  "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "type": "module",
+  "license": "Apache-2.0",
   "files": [
     "dist/**"
   ],


### PR DESCRIPTION
Set `type: module` for packages and use `main: ` to point to their module index.js file (which does not bundle its dependencies).